### PR TITLE
Propagate HTTP error codes from InternetManager

### DIFF
--- a/src/main/kotlin/atm/bloodworkxgaming/serverstarter/InternetManager.kt
+++ b/src/main/kotlin/atm/bloodworkxgaming/serverstarter/InternetManager.kt
@@ -51,6 +51,7 @@ object InternetManager {
         val res = httpClient.newCall(req).execute()
         val source = res?.body()?.source()
 
+        if (!res.isSuccessful) throw IOException("HTTP error code: ${res.code()} for $url")
         source ?: throw IOException("Message body or source from $url was null")
 
         source.use {


### PR DESCRIPTION
Fixes #20

I'm not sure if this is idiomatic Kotlin, let me know if there's a more elegant way to implement this.

Signed-off-by: Greg Harris <gharris1727@gmail.com>