### PR TITLE
Fix Github Redirection Handling in Shell

### DIFF
--- a/src/main/resources/startserver.sh
+++ b/src/main/resources/startserver.sh
@@ -28,7 +28,7 @@ fi
 			which curl >> /dev/null
 			if [ $? -eq 0 ]; then
 				echo "DEBUG: (curl) Downloading ${URL}"
-				curl -o serverstarter-@@serverstarter-libVersion@@.jar "${URL}"
+				curl -o serverstarter-@@serverstarter-libVersion@@.jar -L "${URL}"
 			else
 				echo "Neither wget or curl were found on your system. Please install one and try again"
          fi


### PR DESCRIPTION
### The Problem
Github now seems to redirect release links to an alternate url for downloading files.
However, the current shell script installer does not take this into account.
### The Solution
I added the `-L` redirection option to enable curl to follow redirects and download the correct jar file.
This fixes https://github.com/BloodyMods/ServerStarter/issues/19.