### PR TITLE
Fix connectivity issues in China

### DIFF
--- a/src/main/kotlin/atm/bloodworkxgaming/serverstarter/InternetManager.kt
+++ b/src/main/kotlin/atm/bloodworkxgaming/serverstarter/InternetManager.kt
@@ -22,7 +22,7 @@ class InternetManager(private val configFile: ConfigFile) {
     fun checkConnection(): Boolean {
         var reached = 0
 
-        val urls = listOf("http://example.com", "http://google.com")
+        val urls = listOf("http://example.com", "http://curseforge.com")
         for (url in urls) {
             try {
                 LOGGER.info("Testing $url.")


### PR DESCRIPTION
Fix the bug that Google cannot be accessed in China
In China, they can't access Google normally
However, can access curseforge com
So I changed Google to curseforge com
And submitted this