### PR TITLE
Add a file://{PathToFile} example for modpackUrl with a relative path

### DIFF
--- a/server-setup-config.yaml
+++ b/server-setup-config.yaml
@@ -42,6 +42,8 @@ install:
 
   # Link to where the file where the modpack can be distributed
   # This supports loading from local files as well for most pack types if there is file://{PathToFile} in the beginning
+  # Note: file://{PathToFile} does not need the full path, can be a relative path.
+  # E.g: modpackUrl: file://../modpacks/All+the+Mods+7-0.0.21.zip
   modpackUrl: https://media.forgecdn.net/files/3491/186/All+the+Mods+7-0.0.21.zip
 
   # This is used to specify in which format the modpack is distributed, the server launcher has to handle each individually if their format differs


### PR DESCRIPTION
Add an example for using a local file in the modpackUrl.

It isn't obvious that `{PathToFile}` can be a relative path (or just the filename and extension)